### PR TITLE
Issue #16: Knockback Modifiers have unexpected results

### DIFF
--- a/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
@@ -265,7 +265,7 @@ public class CombatUtil {
 					}
 
 					EnchantmentHelper.doPostDamageEffects(attacker, victim);
-					ItemStack itemstack1 = attacker.getItemInHand(attacker.swingingArm);
+					ItemStack itemstack1 = attacker.getMainHandItem();
 					Object object = victim;
 
 					if (victim instanceof EnderDragonPart) {

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
@@ -185,7 +185,7 @@ public class CombatUtil {
 						}
 					}
 					Vector attackerMotion = config.getAttackerMotion();
-					attacker.setDeltaMovement(attacker.getDeltaMovement().add(attackerMotion.getX(), attackerMotion.getY(), attackerMotion.getZ()));
+					attacker.setDeltaMovement(attacker.getDeltaMovement().multiply(attackerMotion.getX(), attackerMotion.getY(), attackerMotion.getZ()));
 					if (attacker.isInWater()) {
 						attacker.setSprinting(!config.isWaterSprintResetEnabled());
 					} else {

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
@@ -176,6 +176,8 @@ public class CombatUtil {
 							double motZ = Math.min((victimMot.z * victimMotFactor.getZ()) + dv.getZ(), maxVictimMot.getZ());
 
 							victimMot = new Vec3(motX, motY, motZ);
+
+							victim.setDeltaMovement(victimMot);
 						} else {
 							victim.push(
 									(-Mth.sin(attacker.getBukkitYaw() * 0.017453292f) * knockbackLevel * 0.5f),

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
@@ -265,7 +265,9 @@ public class CombatUtil {
 					}
 
 					EnchantmentHelper.doPostDamageEffects(attacker, victim);
-					ItemStack itemstack1 = attacker.getMainHandItem();
+
+					InteractionHand hand = attacker.swingingArm != null ? attacker.swingingArm : InteractionHand.MAIN_HAND;
+					ItemStack itemstack1 = attacker.getItemInHand(hand);
 					Object object = victim;
 
 					if (victim instanceof EnderDragonPart) {


### PR DESCRIPTION
This is a possible fix of KB issue.

The issue most probably happens for the attacker rather than for the target.
I.e. any changes to KB settings (unless attackerMotion option) won't solve the issue.
It happens because Finale adds the current attacker's motion with the vector attackerMotion from config (0.6,1,0.6)
We should multiply the attacker's motion vector instead of adding.