### PR TITLE
Combat Update

### DIFF
--- a/paper/src/main/java/com/github/maxopoly/finale/ConfigParser.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/ConfigParser.java
@@ -4,6 +4,9 @@ import static vg.civcraft.mc.civmodcore.config.ConfigHelper.parseTime;
 
 import java.util.*;
 
+import com.github.maxopoly.finale.combat.DamageDeclineConfig;
+import com.github.maxopoly.finale.combat.knockback.KnockbackStrategy;
+import com.github.maxopoly.finale.combat.knockback.KnockbackStrategyType;
 import com.github.maxopoly.finale.misc.knockback.KnockbackConfig;
 import com.github.maxopoly.finale.misc.knockback.KnockbackModifier;
 import com.github.maxopoly.finale.misc.knockback.KnockbackType;
@@ -436,14 +439,25 @@ public class ConfigParser {
 		double knockbackLevelMultiplier = config.getDouble("knockbackLevelMultiplier", 0.6);
 		int cpsLimit = 9;
 		long cpsCounterInterval = 1000;
+		DamageDeclineConfig damageDeclineConfig = new DamageDeclineConfig(true, 0.1);
 		if (config.isConfigurationSection("cps")) {
 			ConfigurationSection cpsSection = config.getConfigurationSection("cps");
 			cpsLimit = cpsSection.getInt("limit", cpsLimit);
 			cpsCounterInterval = cpsSection.getLong("counterInterval", cpsCounterInterval);
+			if (cpsSection.isConfigurationSection("damageDecline")) {
+				ConfigurationSection damageDeclineSection = cpsSection.getConfigurationSection("damageDecline");
+				boolean damageDeclineEnabled = damageDeclineSection.getBoolean("enabled", true);
+				double damageDeclineFactor = damageDeclineSection.getDouble("factor", 0.1);
+				damageDeclineConfig = new DamageDeclineConfig(damageDeclineEnabled, damageDeclineFactor);
+			}
 		}
+		String knockbackStrategyTypeStr = config.getString("strategy", "normal").toUpperCase();
+		KnockbackStrategyType knockbackStrategyType = KnockbackStrategyType.valueOf(knockbackStrategyTypeStr);
+		KnockbackStrategy knockbackStrategy = knockbackStrategyType.getKnockbackStrategy();
 
-		return new CombatConfig(attackCooldownEnabled, knockbackSwordsEnabled, sprintResetEnabled, waterSprintResetEnabled, cpsLimit, cpsCounterInterval, maxReach, sweepEnabled, combatSounds,
-				knockbackLevelMultiplier, normalConfig, sprintConfig, victimMotion, maxVictimMotion, attackerMotion);
+		return new CombatConfig(attackCooldownEnabled, knockbackSwordsEnabled, sprintResetEnabled, waterSprintResetEnabled,
+				cpsLimit, cpsCounterInterval, damageDeclineConfig, maxReach, sweepEnabled, combatSounds,
+				knockbackLevelMultiplier, normalConfig, sprintConfig, victimMotion, maxVictimMotion, attackerMotion, knockbackStrategy);
 	}
 
 	private KnockbackConfig parseKnockbackConfig(ConfigurationSection config, String name, KnockbackConfig def) {

--- a/paper/src/main/java/com/github/maxopoly/finale/Finale.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/Finale.java
@@ -17,6 +17,7 @@ import com.github.maxopoly.finale.listeners.PlayerListener;
 import com.github.maxopoly.finale.listeners.PotionListener;
 import com.github.maxopoly.finale.listeners.ToolProtectionListener;
 import com.github.maxopoly.finale.listeners.VelocityFixListener;
+import com.github.maxopoly.finale.listeners.WarpFruitListener;
 import com.github.maxopoly.finale.listeners.WeaponModificationListener;
 import com.github.maxopoly.finale.overlay.ScoreboardHUD;
 import org.bukkit.Bukkit;
@@ -91,6 +92,7 @@ public class Finale extends ACivMod {
 		if (config.isItemCDEnabled()) {
 			Bukkit.getPluginManager().registerEvents(new GappleCooldownListener(config.getItemCooldown()), this);
 		}
+		Bukkit.getPluginManager().registerEvents(new WarpFruitListener(), this);
 		Bukkit.getPluginManager().registerEvents(new WeaponModificationListener(), this);
 		Bukkit.getPluginManager().registerEvents(new ExtraDurabilityListener(), this);
 		Bukkit.getPluginManager().registerEvents(new EnchantmentDisableListener(config.getDisabledEnchants()), this);
@@ -99,6 +101,7 @@ public class Finale extends ACivMod {
 		Bukkit.getPluginManager().registerEvents(new DamageListener(config.getDamageModifiers()), this);
 		Bukkit.getPluginManager().registerEvents(new ScoreboardHUD(settingsManager), this);
 		Bukkit.getPluginManager().registerEvents(new ToolProtectionListener(settingsManager), this);
+
 	}
 
 	private void registerCommands() {

--- a/paper/src/main/java/com/github/maxopoly/finale/FinaleManager.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/FinaleManager.java
@@ -8,6 +8,7 @@ import com.github.maxopoly.finale.combat.SprintHandler;
 import com.github.maxopoly.finale.misc.ArmourModifier;
 import com.github.maxopoly.finale.misc.SaturationHealthRegenHandler;
 import com.github.maxopoly.finale.misc.WeaponModifier;
+import com.github.maxopoly.finale.misc.warpfruit.WarpFruitTracker;
 import com.github.maxopoly.finale.potion.PotionHandler;
 import java.util.Map;
 
@@ -25,8 +26,12 @@ public class FinaleManager {
 	private WeaponModifier weaponModifier;
 	private ArmourModifier armourModifier;
 	private PotionHandler potionHandler;
+
+
 	private boolean invulTicksEnabled;
 	private Map<EntityDamageEvent.DamageCause, Integer> invulnerableTicks;
+
+	private WarpFruitTracker warpFruitTracker;
 
 	private SprintHandler sprintHandler;
 	private CPSHandler cpsHandler;
@@ -34,7 +39,7 @@ public class FinaleManager {
 	private AsyncPacketHandler combatHandler;
 
 	public FinaleManager(boolean debug, boolean attackSpeedEnabled, double attackSpeed, boolean invulTicksEnabled, Map<EntityDamageEvent.DamageCause, Integer> invulnerableTicks, boolean regenHandlerEnabled,
-			boolean ctpOnLogin, SaturationHealthRegenHandler regenHandler, WeaponModifier weaponModifier, ArmourModifier armourModifier, PotionHandler potionHandler, CombatConfig combatConfig) {
+			boolean ctpOnLogin, SaturationHealthRegenHandler regenHandler, WeaponModifier weaponModifier, ArmourModifier armourModifier, PotionHandler potionHandler, CombatConfig combatConfig, WarpFruitTracker warpFruitTracker) {
 		this.debug = debug;
 		this.attackSpeedEnabled = attackSpeedEnabled;
 		this.attackSpeed = attackSpeed;
@@ -47,6 +52,8 @@ public class FinaleManager {
 		this.invulTicksEnabled = invulTicksEnabled;
 		this.invulnerableTicks = invulnerableTicks;
 		this.ctpOnLogin = ctpOnLogin;
+
+		this.warpFruitTracker = warpFruitTracker;
 		
 		this.cpsHandler = new CPSHandler();
 		this.sprintHandler = new SprintHandler();
@@ -112,5 +119,9 @@ public class FinaleManager {
 
 	public boolean isRegenHandlerEnabled() {
 		return regenHandlerEnabled;
+	}
+
+	public WarpFruitTracker getWarpFruitTracker() {
+		return warpFruitTracker;
 	}
 }

--- a/paper/src/main/java/com/github/maxopoly/finale/FinaleManager.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/FinaleManager.java
@@ -4,6 +4,7 @@ import com.comphenix.protocol.ProtocolLibrary;
 import com.github.maxopoly.finale.combat.AsyncPacketHandler;
 import com.github.maxopoly.finale.combat.CPSHandler;
 import com.github.maxopoly.finale.combat.CombatConfig;
+import com.github.maxopoly.finale.combat.SprintHandler;
 import com.github.maxopoly.finale.misc.ArmourModifier;
 import com.github.maxopoly.finale.misc.SaturationHealthRegenHandler;
 import com.github.maxopoly.finale.misc.WeaponModifier;
@@ -26,7 +27,8 @@ public class FinaleManager {
 	private PotionHandler potionHandler;
 	private boolean invulTicksEnabled;
 	private Map<EntityDamageEvent.DamageCause, Integer> invulnerableTicks;
-	
+
+	private SprintHandler sprintHandler;
 	private CPSHandler cpsHandler;
 	private CombatConfig combatConfig;
 	private AsyncPacketHandler combatHandler;
@@ -47,6 +49,7 @@ public class FinaleManager {
 		this.ctpOnLogin = ctpOnLogin;
 		
 		this.cpsHandler = new CPSHandler();
+		this.sprintHandler = new SprintHandler();
 
 		Bukkit.getScheduler().runTaskAsynchronously(Finale.getPlugin(), () -> ProtocolLibrary.getProtocolManager().getAsynchronousManager().registerAsyncHandler(combatHandler = new AsyncPacketHandler(combatConfig)).start());
 	}
@@ -74,7 +77,11 @@ public class FinaleManager {
 	public SaturationHealthRegenHandler getPassiveRegenHandler() {
 		return regenHandler;
 	}
-	
+
+	public SprintHandler getSprintHandler() {
+		return sprintHandler;
+	}
+
 	public CPSHandler getCPSHandler() {
 		return cpsHandler;
 	}

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/CombatConfig.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/CombatConfig.java
@@ -1,6 +1,7 @@
 package com.github.maxopoly.finale.combat;
 
 import com.github.maxopoly.finale.Finale;
+import com.github.maxopoly.finale.combat.knockback.KnockbackStrategy;
 import com.github.maxopoly.finale.misc.knockback.KnockbackConfig;
 import com.github.maxopoly.finale.misc.knockback.KnockbackModifier;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -10,6 +11,7 @@ public class CombatConfig {
 
 	private int cpsLimit;
 	private long cpsCounterInterval;
+	private DamageDeclineConfig damageDeclineConfig;
 	private boolean attackCooldownEnabled;
 	private boolean knockbackSwordsEnabled;
 	private boolean sprintResetEnabled;
@@ -23,16 +25,19 @@ public class CombatConfig {
 	private Vector victimMotion;
 	private Vector maxVictimMotion;
 	private Vector attackerMotion;
+	private KnockbackStrategy knockbackStrategy;
 
-	public CombatConfig(boolean attackCooldownEnabled, boolean knockbackSwordsEnabled, boolean sprintResetEnabled, boolean waterSprintResetEnabled, int cpsLimit, long cpsCounterInterval, double maxReach, boolean sweepEnabled, CombatSoundConfig combatSounds,
-						double knockbackLevelMultiplier, KnockbackConfig normalConfig, KnockbackConfig sprintConfig, Vector victimMotion, Vector maxVictimMotion,
-						Vector attackerMotion) {
+	public CombatConfig(boolean attackCooldownEnabled, boolean knockbackSwordsEnabled, boolean sprintResetEnabled, boolean waterSprintResetEnabled,
+						int cpsLimit, long cpsCounterInterval, DamageDeclineConfig damageDeclineConfig, double maxReach, boolean sweepEnabled,
+						CombatSoundConfig combatSounds, double knockbackLevelMultiplier, KnockbackConfig normalConfig, KnockbackConfig sprintConfig,
+						Vector victimMotion, Vector maxVictimMotion, Vector attackerMotion, KnockbackStrategy knockbackStrategy) {
 		this.attackCooldownEnabled = attackCooldownEnabled;
 		this.knockbackSwordsEnabled = knockbackSwordsEnabled;
 		this.sprintResetEnabled = sprintResetEnabled;
 		this.waterSprintResetEnabled = waterSprintResetEnabled;
 		this.cpsLimit = cpsLimit;
 		this.cpsCounterInterval = cpsCounterInterval;
+		this.damageDeclineConfig = damageDeclineConfig;
 		this.maxReach = maxReach;
 		this.sweepEnabled = sweepEnabled;
 		this.combatSounds = combatSounds;
@@ -42,6 +47,7 @@ public class CombatConfig {
 		this.victimMotion = victimMotion;
 		this.maxVictimMotion = maxVictimMotion;
 		this.attackerMotion = attackerMotion;
+		this.knockbackStrategy = knockbackStrategy;
 	}
 
 	private void setKnockbackConfig(FileConfiguration config, String name, KnockbackConfig knockbackConfig) {
@@ -114,6 +120,10 @@ public class CombatConfig {
 		return cpsCounterInterval;
 	}
 
+	public DamageDeclineConfig getDamageDeclineConfig() {
+		return damageDeclineConfig;
+	}
+
 	public boolean isKnockbackSwordsEnabled() {
 		return knockbackSwordsEnabled;
 	}
@@ -132,6 +142,10 @@ public class CombatConfig {
 
 	public CombatSoundConfig getCombatSounds() {
 		return combatSounds;
+	}
+
+	public KnockbackStrategy getKnockbackStrategy() {
+		return knockbackStrategy;
 	}
 
 	public void setNormalConfig(KnockbackConfig normalConfig) {

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/CombatUtil.java
@@ -74,15 +74,17 @@ public class CombatUtil {
 			if (damage > 0.0F || f1 > 0.0F) {
 				boolean dealtExtraKnockback = false;
 				byte baseKnockbackLevel = 0;
-				int knockbackLevel = baseKnockbackLevel + EnchantmentHelper.getKnockbackBonus(attacker);
+				float knockbackLevel = baseKnockbackLevel;
+
+				if (config.isKnockbackSwordsEnabled()) {
+					knockbackLevel += config.getKnockbackLevelMultiplier() * EnchantmentHelper.getKnockbackBonus(attacker);
+				}
 
 				if (sprintHandler.isSprinting(attacker) && shouldKnockback) {
 					if (config.getCombatSounds().isKnockbackEnabled()) {
 						sendSoundEffect(attacker, attacker.getX(), attacker.getY(), attacker.getZ(), SoundEvents.PLAYER_ATTACK_WEAK, attacker.getSoundSource(), 1.0F, 1.0F); // Paper - send while respecting visibility
 					}
-					if (!config.isKnockbackSwordsEnabled()) {
-						++knockbackLevel;
-					}
+					++knockbackLevel;
 					dealtExtraKnockback = true;
 				}
 

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/DamageDeclineConfig.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/DamageDeclineConfig.java
@@ -1,0 +1,20 @@
+package com.github.maxopoly.finale.combat;
+
+public class DamageDeclineConfig {
+
+	private boolean enabled;
+	private double factor;
+
+	public DamageDeclineConfig(boolean enabled, double factor) {
+		this.enabled = enabled;
+		this.factor = factor;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public double getFactor() {
+		return factor;
+	}
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/SprintHandler.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/SprintHandler.java
@@ -1,0 +1,66 @@
+package com.github.maxopoly.finale.combat;
+
+import com.github.maxopoly.finale.Finale;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class SprintHandler implements Listener {
+
+	@EventHandler
+	public void onQuit(PlayerQuitEvent e) {
+		Player player = e.getPlayer();
+
+		if (sprinting.contains(player.getUniqueId())) {
+			sprinting.remove(player.getUniqueId());
+		}
+	}
+
+	private Set<UUID> sprinting = new HashSet<>();
+
+	public SprintHandler() {
+		Bukkit.getPluginManager().registerEvents(this, Finale.getPlugin());
+	}
+
+	public void startSprinting(net.minecraft.world.entity.player.Player player) {
+		startSprinting(player.getUUID());
+	}
+
+	public void stopSprinting(net.minecraft.world.entity.player.Player player) {
+		stopSprinting(player.getUUID());
+	}
+
+	public void startSprinting(Player player) {
+		startSprinting(player.getUniqueId());
+	}
+
+	public void stopSprinting(Player player) {
+		stopSprinting(player.getUniqueId());
+	}
+
+	public void startSprinting(UUID uuid) {
+		sprinting.add(uuid);
+	}
+
+	public void stopSprinting(UUID uuid) {
+		sprinting.remove(uuid);
+	}
+
+	public boolean isSprinting(net.minecraft.world.entity.player.Player player) {
+		return isSprinting(player.getUUID());
+	}
+
+	public boolean isSprinting(Player player) {
+		return isSprinting(player.getUniqueId());
+	}
+
+	public boolean isSprinting(UUID uuid) {
+		return sprinting.contains(uuid);
+	}
+
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/ClassicKnockback.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/ClassicKnockback.java
@@ -1,0 +1,70 @@
+package com.github.maxopoly.finale.combat.knockback;
+
+import com.github.maxopoly.finale.Finale;
+import com.github.maxopoly.finale.combat.CombatConfig;
+import com.github.maxopoly.finale.combat.SprintHandler;
+import com.github.maxopoly.finale.misc.knockback.KnockbackConfig;
+import com.github.maxopoly.finale.misc.knockback.KnockbackModifier;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.util.Vector;
+
+public class ClassicKnockback implements KnockbackStrategy {
+
+	@Override
+	public void handleKnockback(Player attacker, Entity entity, int knockbackLevel) {
+		CombatConfig config = Finale.getPlugin().getManager().getCombatConfig();
+		SprintHandler sprintHandler = Finale.getPlugin().getManager().getSprintHandler();
+
+		KnockbackConfig knockbackConfig = sprintHandler.isSprinting(attacker) ? config.getSprintConfig() : config.getNormalConfig();
+		KnockbackModifier modifier = knockbackConfig.getGroundModifier();
+
+		if (!entity.isOnGround()) {
+			modifier = knockbackConfig.getAirModifier();
+		}
+
+		if (entity.isInWater()) {
+			modifier = knockbackConfig.getWaterModifier();
+		}
+
+		double deltaX = (-Mth.sin(attacker.getYRot() * 0.017453292F) * 0.5F);
+		double deltaY = 0.1;
+		double deltaZ = (Mth.cos(attacker.getYRot() * 0.017453292F) * 0.5F);
+		if (knockbackLevel > 0) {
+			deltaX *= knockbackLevel;
+			deltaZ *= knockbackLevel;
+		}
+
+		Vector deltaVec = new Vector(deltaX, deltaY, deltaZ);
+		Vec3 currentDelta = entity.getDeltaMovement();
+		Vector currentDeltaVec = new Vector(currentDelta.x, currentDelta.y, currentDelta.z);
+		Vector modifiedDelta = modifier.modifyKnockback(currentDeltaVec, deltaVec);
+
+		if (entity instanceof LivingEntity) {
+			LivingEntity livingEntity = (LivingEntity) entity;
+			double kbReductionFactor = 1.0D - livingEntity.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
+			modifiedDelta = modifiedDelta.clone().multiply(kbReductionFactor);
+		}
+
+		entity.push(modifiedDelta.getX(), modifiedDelta.getY(), modifiedDelta.getZ());
+
+		Vector attackerMotion = config.getAttackerMotion();
+		attacker.setDeltaMovement(attacker.getDeltaMovement().multiply(attackerMotion.getX(), attackerMotion.getY(), attackerMotion.getZ()));
+		if (attacker.isInWater()) {
+			if (config.isWaterSprintResetEnabled()) {
+				//attacker.setSprinting(false);
+				sprintHandler.stopSprinting(attacker);
+			}
+		} else {
+			if (config.isSprintResetEnabled()) {
+				//attacker.setSprinting(false); // looks like modern minecraft finally defeated w-tapping, but we work around it
+				sprintHandler.stopSprinting(attacker);
+			}
+		}
+	}
+
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/ClassicKnockback.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/ClassicKnockback.java
@@ -16,7 +16,7 @@ import org.bukkit.util.Vector;
 public class ClassicKnockback implements KnockbackStrategy {
 
 	@Override
-	public void handleKnockback(Player attacker, Entity entity, int knockbackLevel) {
+	public void handleKnockback(Player attacker, Entity entity, float knockbackLevel) {
 		CombatConfig config = Finale.getPlugin().getManager().getCombatConfig();
 		SprintHandler sprintHandler = Finale.getPlugin().getManager().getSprintHandler();
 

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/ClassicKnockback.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/ClassicKnockback.java
@@ -20,7 +20,7 @@ public class ClassicKnockback implements KnockbackStrategy {
 		CombatConfig config = Finale.getPlugin().getManager().getCombatConfig();
 		SprintHandler sprintHandler = Finale.getPlugin().getManager().getSprintHandler();
 
-		KnockbackConfig knockbackConfig = sprintHandler.isSprinting(attacker) ? config.getSprintConfig() : config.getNormalConfig();
+		KnockbackConfig knockbackConfig = (knockbackLevel > 0) ? config.getSprintConfig() : config.getNormalConfig();
 		KnockbackModifier modifier = knockbackConfig.getGroundModifier();
 
 		if (!entity.isOnGround()) {

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/KnockbackStrategy.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/KnockbackStrategy.java
@@ -5,6 +5,6 @@ import net.minecraft.world.entity.player.Player;
 
 public interface KnockbackStrategy {
 
-	void handleKnockback(Player attacker, Entity victim, int knockbackLevel);
+	void handleKnockback(Player attacker, Entity victim, float knockbackLevel);
 
 }

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/KnockbackStrategy.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/KnockbackStrategy.java
@@ -1,0 +1,10 @@
+package com.github.maxopoly.finale.combat.knockback;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+
+public interface KnockbackStrategy {
+
+	void handleKnockback(Player attacker, Entity victim, int knockbackLevel);
+
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/KnockbackStrategyType.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/KnockbackStrategyType.java
@@ -1,0 +1,17 @@
+package com.github.maxopoly.finale.combat.knockback;
+
+public enum KnockbackStrategyType {
+
+	STANDARD(new StandardKnockback()),
+	CLASSIC(new ClassicKnockback());
+
+	private KnockbackStrategy knockbackStrategy;
+
+	KnockbackStrategyType(KnockbackStrategy knockbackStrategy) {
+		this.knockbackStrategy = knockbackStrategy;
+	}
+
+	public KnockbackStrategy getKnockbackStrategy() {
+		return knockbackStrategy;
+	}
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/StandardKnockback.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/StandardKnockback.java
@@ -15,7 +15,7 @@ import org.bukkit.util.Vector;
 public class StandardKnockback implements KnockbackStrategy {
 
 	@Override
-	public void handleKnockback(Player attacker, Entity entity, int knockbackLevel) {
+	public void handleKnockback(Player attacker, Entity entity, float knockbackLevel) {
 		CombatConfig config = Finale.getPlugin().getManager().getCombatConfig();
 		SprintHandler sprintHandler = Finale.getPlugin().getManager().getSprintHandler();
 

--- a/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/StandardKnockback.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/combat/knockback/StandardKnockback.java
@@ -1,0 +1,97 @@
+package com.github.maxopoly.finale.combat.knockback;
+
+import com.github.maxopoly.finale.Finale;
+import com.github.maxopoly.finale.combat.CombatConfig;
+import com.github.maxopoly.finale.combat.SprintHandler;
+import com.github.maxopoly.finale.misc.knockback.KnockbackConfig;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.util.Vector;
+
+public class StandardKnockback implements KnockbackStrategy {
+
+	@Override
+	public void handleKnockback(Player attacker, Entity entity, int knockbackLevel) {
+		CombatConfig config = Finale.getPlugin().getManager().getCombatConfig();
+		SprintHandler sprintHandler = Finale.getPlugin().getManager().getSprintHandler();
+
+		if (entity instanceof LivingEntity) {
+			LivingEntity victim = (LivingEntity) entity;
+			if (sprintHandler.isSprinting(attacker)) {
+				knockbackLevel++;
+			}
+			double strength = knockbackLevel * config.getKnockbackLevelMultiplier() * 0.5;
+			double x = Mth.sin(attacker.getYRot() * 0.017453292F);
+			double z = (-Mth.cos(attacker.getYRot() * 0.017453292F));
+			strength *= 1.0D - victim.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
+			if (strength > 0.0) {
+				victim.hasImpulse = true;
+				Vec3 vec3d = victim.getDeltaMovement();
+				Vec3 vec3d1 = (new Vec3(x, 0.0D, z)).normalize().scale(strength);
+
+				Vector victimMotion = config.getVictimMotion();
+
+				double dx = (vec3d.x * victimMotion.getX()) - vec3d1.x;
+				//double dy = victim.onGround ? Math.min(0.4D, (vec3d.y * victimMotion.getY()) + strength) : vec3d.y;
+				double dy = (vec3d.y * victimMotion.getY());
+				double dz = (vec3d.z * victimMotion.getZ()) - vec3d1.z;
+
+				Vector start = new Vector(vec3d.x, vec3d.y, vec3d.z);
+				Vector dv = new Vector(dx, dy, dz);
+
+				boolean isSprinting = sprintHandler.isSprinting(attacker);
+				KnockbackConfig knockbackConfig = isSprinting ? config.getSprintConfig() : config.getNormalConfig();
+
+				if (victim.isInWater()) {
+					dv = knockbackConfig.getWaterModifier().modifyKnockback(start, dv);
+				} else {
+					if (!victim.isOnGround()) {
+						dv = knockbackConfig.getAirModifier().modifyKnockback(start, dv);
+					} else {
+						dv = knockbackConfig.getGroundModifier().modifyKnockback(start, dv);
+					}
+				}
+
+				victim.setDeltaMovement(dv.getX(), dv.getY(), dv.getZ());
+
+				Vec3 currentMovement = victim.getDeltaMovement();
+				org.bukkit.util.Vector delta = new org.bukkit.util.Vector(currentMovement.x - vec3d.x, currentMovement.y - vec3d.y, currentMovement.z - vec3d.z);
+
+				victim.setDeltaMovement(vec3d);
+				if (attacker == null || new com.destroystokyo.paper.event.entity.EntityKnockbackByEntityEvent((org.bukkit.entity.LivingEntity) victim.getBukkitEntity(), attacker.getBukkitEntity(), (float) strength, delta).callEvent()) {
+					double dmx = vec3d.x + delta.getX();
+					double dmy = vec3d.y + delta.getY();
+					double dmz = vec3d.z + delta.getZ();
+					Vector maxVictimMotion = config.getMaxVictimMotion();
+
+					victim.setDeltaMovement(
+						Math.min(dmx, maxVictimMotion.getX()),
+						Math.min(dmy, maxVictimMotion.getY()),
+						Math.min(dmz, maxVictimMotion.getZ())
+					);
+				}
+			}
+		} else {
+			entity.push((-Mth.sin(attacker.getYRot() * 0.017453292F) * (float) knockbackLevel * 0.5F), 0.1D, (double) (Mth.cos(attacker.getYRot() * 0.017453292F) * (float) knockbackLevel * 0.5F));
+		}
+
+		Vector attackerMotion = config.getAttackerMotion();
+		attacker.setDeltaMovement(attacker.getDeltaMovement().multiply(attackerMotion.getX(), attackerMotion.getY(), attackerMotion.getZ()));
+		if (attacker.isInWater()) {
+			if (config.isWaterSprintResetEnabled()) {
+				//attacker.setSprinting(false);
+				sprintHandler.stopSprinting(attacker);
+			}
+		} else {
+			if (config.isSprintResetEnabled()) {
+				//attacker.setSprinting(false); // looks like modern minecraft finally defeated w-tapping, but we work around it
+				sprintHandler.stopSprinting(attacker);
+			}
+		}
+	}
+
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/command/CombatConfigCommand.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/command/CombatConfigCommand.java
@@ -45,6 +45,12 @@ public class CombatConfigCommand extends BaseCommand {
 		sender.sendMessage(ChatColor.GREEN + "You have saved the combat config.");
 	}
 
+	@Subcommand("noDamageTicks")
+	public void noDamageTicks(Player sender, int value) {
+		Finale.getPlugin().getManager().getInvulnerableTicks().put(DamageCause.ENTITY_ATTACK, value);
+		sender.sendMessage(ChatColor.GREEN + "Set noDamageTicks to " + value);
+	}
+
 	@Subcommand("set")
 	@Syntax("<property> <value>|[velX] [velY] [velZ]")
 	@Description("Set regular combat config values.")

--- a/paper/src/main/java/com/github/maxopoly/finale/external/FinaleSettingManager.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/external/FinaleSettingManager.java
@@ -13,6 +13,10 @@ import vg.civcraft.mc.civmodcore.players.settings.impl.IntegerSetting;
 
 public class FinaleSettingManager {
 
+	private BooleanSetting vanillaTimeWarpCooldown;
+	private BooleanSetting actionBarTimeWarpCooldown;
+	private BooleanSetting sideBarTimeWarpCooldown;
+
 	private BooleanSetting vanillaPearlCooldown;
 	private BooleanSetting vanillaItemCooldown;
 	private BooleanSetting actionBarItemCooldown;
@@ -40,6 +44,21 @@ public class FinaleSettingManager {
 				"finaleGammaBright",
 				"Do you want permanent night vision");
 		PlayerSettingAPI.registerSetting(permanentNightVision, menu);
+
+		vanillaTimeWarpCooldown = new BooleanSetting(plugin, false, "Use vanilla timewarp cooldown",
+			"finaleVanillaTimewarpCooldown",
+			"Should timewarp cooldown be shown as an overlay on the item, the way it is done in vanilla");
+		PlayerSettingAPI.registerSetting(vanillaTimeWarpCooldown, menu);
+
+		actionBarTimeWarpCooldown = new BooleanSetting(plugin, true, "Show timewarp cooldown on action bar",
+			"finaleActionBarTimewarpCooldown",
+			"Should timewarp cooldown be shown on the action bar at the bottom of your screen");
+		PlayerSettingAPI.registerSetting(actionBarTimeWarpCooldown, menu);
+
+		sideBarTimeWarpCooldown = new BooleanSetting(plugin, false, "Show timewarp cooldown in side bar",
+			"finaleSideBarTimewarpCooldown",
+			"Should timewarp cooldown be shown on the sidebar");
+		PlayerSettingAPI.registerSetting(sideBarTimeWarpCooldown, menu);
 
 		vanillaPearlCooldown = new BooleanSetting(plugin, false, "Use vanilla pearl cooldown",
 				"finaleVanillaPearlCooldown",
@@ -96,6 +115,18 @@ public class FinaleSettingManager {
 
 	public boolean setVanillaItemCooldown(UUID uuid) {
 		return vanillaItemCooldown.getValue(uuid);
+	}
+
+	public boolean vanillaTimewarpCooldown(UUID uuid) {
+		return vanillaTimeWarpCooldown.getValue(uuid);
+	}
+
+	public boolean sideBarTimewarpCooldown(UUID uuid) {
+		return sideBarTimeWarpCooldown.getValue(uuid);
+	}
+
+	public boolean actionBarTimewarpCooldown(UUID uuid) {
+		return actionBarTimeWarpCooldown.getValue(uuid);
 	}
 
 	public int getToolProtectionThreshhold(UUID uuid) {

--- a/paper/src/main/java/com/github/maxopoly/finale/listeners/DamageListener.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/listeners/DamageListener.java
@@ -111,7 +111,6 @@ public class DamageListener implements Listener {
 			double damageReduction = (1 - declineFactor) >= 0 ? (1 - declineFactor) : 0;
 			double damage = e.getDamage() * damageReduction;
 			attacker.sendMessage(ChatColor.RED + "You're over the CPS limit of " + cpsLimit + "! (-" + ((int) (declineFactor * 100)) + "%)");
-			attacker.sendMessage("Damage: " + damage);
 			e.setDamage(damage);
 		}
 	}

--- a/paper/src/main/java/com/github/maxopoly/finale/listeners/DamageListener.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/listeners/DamageListener.java
@@ -105,7 +105,7 @@ public class DamageListener implements Listener {
 				return;
 			}
 
-			int aboveLimit = attackerCPS - cpsLimit;
+			int aboveLimit = 1 + (attackerCPS - cpsLimit);
 			double declineFactor = damageDeclineConfig.getFactor();
 			declineFactor *= aboveLimit;
 			double damageReduction = (1 - declineFactor) >= 0 ? (1 - declineFactor) : 0;

--- a/paper/src/main/java/com/github/maxopoly/finale/listeners/WarpFruitListener.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/listeners/WarpFruitListener.java
@@ -1,0 +1,105 @@
+package com.github.maxopoly.finale.listeners;
+
+import com.github.maxopoly.finale.Finale;
+import com.github.maxopoly.finale.misc.warpfruit.WarpFruitTracker;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public class WarpFruitListener implements Listener {
+
+	@EventHandler
+	public void onPlayerQuit(PlayerQuitEvent event) {
+		WarpFruitTracker warpFruitTracker = Finale.getPlugin().getManager().getWarpFruitTracker();
+		Player player = event.getPlayer();
+		warpFruitTracker.quit(player);
+	}
+
+	@EventHandler
+	public void onPlayerMove(PlayerMoveEvent event) {
+		WarpFruitTracker warpFruitTracker = Finale.getPlugin().getManager().getWarpFruitTracker();
+		warpFruitTracker.logLocation(event.getPlayer());
+	}
+
+	private boolean isChorusHolder(Player player) {
+		ItemStack mainItem = player.getInventory().getItemInMainHand();
+		ItemStack offItem = player.getInventory().getItemInOffHand();
+		return (mainItem != null && mainItem.getType() == Material.CHORUS_FRUIT) || (offItem != null && offItem.getType() == Material.CHORUS_FRUIT);
+	}
+
+	private void removeSpectral(WarpFruitTracker warpFruitTracker, Player player) {
+		if (warpFruitTracker.isSpectralWhileChanneling() && player.hasPotionEffect(PotionEffectType.GLOWING)) {
+			player.removePotionEffect(PotionEffectType.GLOWING);
+		}
+	}
+
+	@EventHandler
+	public void onEatingWarpFruit(PlayerInteractEvent event) {
+		WarpFruitTracker warpFruitTracker = Finale.getPlugin().getManager().getWarpFruitTracker();
+		Player player = event.getPlayer();
+		if (warpFruitTracker.onCooldown(player)) {
+			return;
+		}
+		if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+			if (!isChorusHolder(player)) {
+				return;
+			}
+			new BukkitRunnable() {
+
+				@Override
+				public void run() {
+					if (!player.isOnline() || player.isDead()) {
+						removeSpectral(warpFruitTracker, player);
+						cancel();
+						return;
+					}
+					if (player.getItemInUse() == null){
+						removeSpectral(warpFruitTracker, player);
+						cancel();
+						return;
+					}
+					if (player.getItemInUse().getType() != Material.CHORUS_FRUIT) {
+						removeSpectral(warpFruitTracker, player);
+						cancel();
+						return;
+					}
+					if (warpFruitTracker.onCooldown(player)) {
+						removeSpectral(warpFruitTracker, player);
+						cancel();
+						return;
+					}
+					if (warpFruitTracker.isSpectralWhileChanneling() && !player.hasPotionEffect(PotionEffectType.GLOWING)) {
+						player.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, Integer.MAX_VALUE, 0));
+					}
+					warpFruitTracker.animate(player);
+				}
+			}.runTaskTimer(Finale.getPlugin(), 0L,1L);
+		}
+	}
+
+	@EventHandler
+	public void onEatWarpFruit(PlayerItemConsumeEvent event) {
+		WarpFruitTracker warpFruitTracker = Finale.getPlugin().getManager().getWarpFruitTracker();
+		Player player = event.getPlayer();
+		ItemStack itemStack = event.getItem();
+		if (itemStack.getType() == Material.CHORUS_FRUIT) {
+			if (warpFruitTracker.timewarp(player)) {
+				removeSpectral(warpFruitTracker, player);
+				player.getInventory().removeItem(new ItemStack(Material.CHORUS_FRUIT, 1));
+				player.updateInventory();
+				event.setCancelled(true);
+			}
+		}
+	}
+
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/misc/CooldownHandler.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/misc/CooldownHandler.java
@@ -1,0 +1,107 @@
+package com.github.maxopoly.finale.misc;
+
+import com.github.maxopoly.finale.Finale;
+import com.github.maxopoly.finale.external.FinaleSettingManager;
+import java.text.DecimalFormat;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.civmodcore.players.scoreboard.bottom.BottomLine;
+import vg.civcraft.mc.civmodcore.players.scoreboard.bottom.BottomLineAPI;
+import vg.civcraft.mc.civmodcore.players.scoreboard.side.CivScoreBoard;
+import vg.civcraft.mc.civmodcore.players.scoreboard.side.ScoreBoardAPI;
+import vg.civcraft.mc.civmodcore.utilities.cooldowns.ICoolDownHandler;
+import vg.civcraft.mc.civmodcore.utilities.cooldowns.TickCoolDownHandler;
+
+public class CooldownHandler {
+
+	private String identifier;
+	private ICoolDownHandler<UUID> cooldowns;
+	private BiFunction<Player, ICoolDownHandler<UUID>, String> getCooldownText;
+	private long cooldown;
+
+	public CooldownHandler(String identifier, long cooldown, BiFunction<Player, ICoolDownHandler<UUID>, String> getCooldownText) {
+		this.identifier = identifier;
+		this.getCooldownText = getCooldownText;
+		this.cooldown = cooldown;
+
+		this.cooldowns = new TickCoolDownHandler<>(Finale.getPlugin(), cooldown / 50);
+	}
+
+	public long getCooldown() {
+		return cooldown;
+	}
+
+	public void quit(Player player) {
+		cooldowns.removeCooldown(player.getUniqueId());
+	}
+
+	public boolean onCooldown(Player player) {
+		return cooldowns.onCoolDown(player.getUniqueId());
+	}
+
+	public BiFunction<Player, String, String> getCooldownBiFunction() {
+		return (shooter, oldText) -> {
+			if (!cooldowns.onCoolDown(shooter.getUniqueId())) {
+				return null;
+			}
+
+			return getCooldownText.apply(shooter, cooldowns);
+		};
+	}
+
+	private BottomLine cooldownBottomLine;
+
+	public BottomLine getCooldownBottomLine() {
+		if (cooldownBottomLine == null) {
+			cooldownBottomLine = BottomLineAPI.createBottomLine(identifier, 1);
+			cooldownBottomLine.updatePeriodically(getCooldownBiFunction(), 1L);
+		}
+		return cooldownBottomLine;
+	}
+
+	private CivScoreBoard cooldownBoard;
+
+	public CivScoreBoard getCooldownBoard() {
+		if (cooldownBoard == null) {
+			cooldownBoard = ScoreBoardAPI.createBoard(identifier);
+			cooldownBoard.updatePeriodically(getCooldownBiFunction(), 1L);
+		}
+		return cooldownBoard;
+	}
+
+	public void putOnCooldown(Player shooter) {
+		cooldowns.putOnCoolDown(shooter.getUniqueId());
+		FinaleSettingManager settings = Finale.getPlugin().getSettingsManager();
+		if (settings.vanillaTimewarpCooldown(shooter.getUniqueId())) {
+			Bukkit.getScheduler().runTaskLater(Finale.getPlugin(), () -> {
+				// -1, because this is delayed by one tick
+				shooter.setCooldown(Material.CHORUS_FRUIT, (int) cooldowns.getTotalCoolDown() - 1);
+			}, 1);
+		}
+
+		if (settings.actionBarTimewarpCooldown(shooter.getUniqueId())) {
+			BottomLine bottomLine = getCooldownBottomLine();
+			bottomLine.updatePlayer(shooter, getCooldownText.apply(shooter, cooldowns));
+		}
+		if (settings.sideBarTimewarpCooldown(shooter.getUniqueId())) {
+			CivScoreBoard board = getCooldownBoard();
+			board.set(shooter, getCooldownText.apply(shooter, cooldowns));
+		}
+	}
+
+	private static final DecimalFormat df = new DecimalFormat("#.0");
+
+	public static String formatCoolDown(ICoolDownHandler<UUID> cooldowns, UUID uuid) {
+		long cd = cooldowns.getRemainingCoolDown(uuid);
+		if (cd <= 0) {
+			return ChatColor.GREEN + "READY";
+		}
+		//convert from ticks to ms
+		return df.format(cd / 20.0) + " sec";
+	}
+
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/misc/knockback/KnockbackType.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/misc/knockback/KnockbackType.java
@@ -2,15 +2,8 @@ package com.github.maxopoly.finale.misc.knockback;
 
 public enum KnockbackType {
 
-	DIRECT((start, knockback, modifier) -> {
-		return start.clone().multiply(modifier);
-	}),
-	ADD((start, knockback, modifier) -> {
-		return knockback.clone().add(start.clone().multiply(modifier));
-	}),
-	MULTIPLY((start, knockback, modifier) -> {
-		return knockback.clone().multiply(modifier);
-	});
+	ADD((start, knockback, modifier) -> knockback.clone().add(modifier)),
+	MULTIPLY((start, knockback, modifier) -> knockback.clone().multiply(modifier));
 
 	private KnockbackModifier.KnockbackLogic modifierLogic;
 

--- a/paper/src/main/java/com/github/maxopoly/finale/misc/warpfruit/WarpFruitData.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/misc/warpfruit/WarpFruitData.java
@@ -1,0 +1,41 @@
+package com.github.maxopoly.finale.misc.warpfruit;
+
+import com.google.common.collect.EvictingQueue;
+import org.bukkit.Location;
+
+public class WarpFruitData {
+
+	private final WarpFruitTracker tracker;
+
+	private long lastLocationLogTime = 0;
+	private EvictingQueue<Location> locationsLog;
+
+	private double animateAngle = 0;
+
+	public WarpFruitData(WarpFruitTracker tracker) {
+		this.tracker = tracker;
+
+		locationsLog = EvictingQueue.create(tracker.getLogSize());
+	}
+
+	public void logLocation(Location loc) {
+		if (System.currentTimeMillis() - lastLocationLogTime < tracker.getLogInterval()) {
+			return;
+		}
+		locationsLog.add(loc);
+		lastLocationLogTime = System.currentTimeMillis();
+	}
+
+	public Location getTimeWarpLocation() {
+		return locationsLog.peek();
+	}
+
+	public void setAnimateAngle(double animateAngle) {
+		this.animateAngle = animateAngle;
+	}
+
+	public double getAnimateAngle() {
+		return animateAngle;
+	}
+
+}

--- a/paper/src/main/java/com/github/maxopoly/finale/misc/warpfruit/WarpFruitTracker.java
+++ b/paper/src/main/java/com/github/maxopoly/finale/misc/warpfruit/WarpFruitTracker.java
@@ -1,0 +1,220 @@
+package com.github.maxopoly.finale.misc.warpfruit;
+
+import com.github.maxopoly.finale.Finale;
+import com.github.maxopoly.finale.misc.CooldownHandler;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class WarpFruitTracker {
+
+	private static final double ANGLE_INCREMENT = 10;
+	private static final double RADIUS = 1;
+
+	private int logSize;
+	private long logInterval;
+	private long warpFruitCooldown;
+	private double maxDistance;
+	private boolean spectralWhileChanneling;
+
+	private List<PotionEffect> afterEffects;
+
+	private CooldownHandler cooldownHandler;
+	private Map<UUID, WarpFruitData> warpFruitDataMap = new HashMap<>();
+
+	public WarpFruitTracker(int logSize, long logInterval, long warpFruitCooldown, double maxDistance, boolean spectralWhileChanneling, List<PotionEffect> afterEffects) {
+		this.logSize = logSize;
+		this.logInterval = logInterval;
+		this.warpFruitCooldown = warpFruitCooldown;
+		this.maxDistance = maxDistance;
+		this.spectralWhileChanneling = spectralWhileChanneling;
+		this.afterEffects = afterEffects;
+
+		this.cooldownHandler = new CooldownHandler("warpfruitCooldown", warpFruitCooldown, (player, cooldowns) ->
+			ChatColor.DARK_AQUA + "" + ChatColor.BOLD + "Warp fruit: " +
+				ChatColor.AQUA + CooldownHandler.formatCoolDown(cooldowns, player.getUniqueId())
+		);
+	}
+
+	public boolean isSpectralWhileChanneling() {
+		return spectralWhileChanneling;
+	}
+
+	public WarpFruitData getWarpFruitData(Player player) {
+		WarpFruitData warpFruitData = warpFruitDataMap.get(player.getUniqueId());
+		if (warpFruitData == null) {
+			warpFruitData = new WarpFruitData(this);
+			warpFruitDataMap.put(player.getUniqueId(), warpFruitData);
+		}
+		return warpFruitData;
+	}
+
+	public void animate(Player player) {
+		WarpFruitData warpFruitData = getWarpFruitData(player);
+		double animateAngle = warpFruitData.getAnimateAngle();
+
+		Location playerLoc = player.getLocation();
+		double px = playerLoc.getX();
+		double py = playerLoc.getY() + 0.2;
+		double pz = playerLoc.getZ();
+
+		double dx = RADIUS * Math.sin(Math.toRadians(animateAngle));
+		double dz = RADIUS * Math.cos(Math.toRadians(animateAngle));
+
+		Location timeWarpLocation = warpFruitData.getTimeWarpLocation();
+		double tx = timeWarpLocation.getX();
+		double ty = timeWarpLocation.getY() + 0.2;
+		double tz = timeWarpLocation.getZ();
+
+		World world = player.getWorld();
+		Location playerParticleLoc = new Location(world, px + dx, py, pz + dz);
+		Location targetParticleLoc = new Location(world, tx + dx, ty, tz + dz);
+
+		ParticleAudience audience = getParticleAudience(player);
+
+		spawnParticles(audience, playerParticleLoc);
+		spawnParticles(audience, targetParticleLoc);
+
+		animateAngle += ANGLE_INCREMENT;
+		warpFruitData.setAnimateAngle(animateAngle);
+	}
+
+	private void spawnParticles(ParticleAudience audience, Location loc) {
+		List<Player> self = audience.getSelf();
+		List<Player> rest = audience.getRest();
+
+		Particle.DustOptions dustOptions = new Particle.DustOptions(Color.PURPLE, 1);
+		loc.getWorld().spawnParticle(Particle.REDSTONE, rest, null, loc.getX(), loc.getY(), loc.getZ(),
+			1, 0, 0, 0, 0, dustOptions, true);
+
+		dustOptions = new Particle.DustOptions(Color.GREEN, 1);
+		loc.getWorld().spawnParticle(Particle.REDSTONE, self, null, loc.getX(), loc.getY(), loc.getZ(),
+			1, 0, 0, 0, 0, dustOptions, true);
+	}
+
+	public void logLocation(Player player) {
+		WarpFruitData warpFruitData = getWarpFruitData(player);
+		warpFruitData.logLocation(player.getLocation());
+	}
+
+	private void ring(Player player, Location location) {
+		ParticleAudience audience = getParticleAudience(player);
+
+		for (double angle = 0; angle < 360; angle += ANGLE_INCREMENT) {
+			Location loc = location.clone();
+			double dx = RADIUS * Math.sin(Math.toRadians(angle));
+			double dz = RADIUS * Math.cos(Math.toRadians(angle));
+
+			Location partLoc = loc.add(dx, 0.3, dz);
+			spawnParticles(audience, partLoc);
+		}
+	}
+
+	public boolean timewarp(Player player) {
+		if (onCooldown(player)) {
+			return false;
+		}
+
+		WarpFruitData warpFruitData = warpFruitDataMap.get(player.getUniqueId());
+		if (warpFruitData == null) {
+			return false;
+		}
+
+		Location warpLoc = warpFruitData.getTimeWarpLocation();
+		if (warpLoc == null) {
+			return false;
+		}
+
+		ring(player, player.getLocation());
+		ring(player, warpLoc);
+
+		World world = warpLoc.getWorld();
+		world.playSound(warpLoc, Sound.ITEM_CHORUS_FRUIT_TELEPORT, 1f, 1f);
+		player.setFallDistance(0);
+		player.teleport(warpLoc);
+		if (!afterEffects.isEmpty()) {
+			player.addPotionEffects(afterEffects);
+		}
+		putOnCooldown(player);
+		return true;
+	}
+
+	public void putOnCooldown(Player shooter) {
+		cooldownHandler.putOnCooldown(shooter);
+	}
+
+	public void quit(Player player) {
+		cooldownHandler.quit(player);
+		warpFruitDataMap.remove(player.getUniqueId());
+	}
+
+	public boolean onCooldown(Player player) {
+		return cooldownHandler.onCooldown(player);
+	}
+
+	public int getLogSize() {
+		return logSize;
+	}
+
+	public long getLogInterval() {
+		return logInterval;
+	}
+
+	public long getWarpFruitCooldown() {
+		return warpFruitCooldown;
+	}
+
+	private ParticleAudience getParticleAudience(Player player) {
+		Collection<? extends Player> players = Bukkit.getOnlinePlayers();
+		List<Player> self = Arrays.asList(player);
+
+		List<Player> rest = new ArrayList<>();
+
+		for (Player onlinePlayer : players) {
+			if (!onlinePlayer.getUniqueId().equals(player.getUniqueId())) {
+				rest.add(onlinePlayer);
+			}
+		}
+
+		ParticleAudience result = new ParticleAudience();
+		result.setSelf(self);
+		result.setRest(rest);
+		return result;
+	}
+
+	private static class ParticleAudience {
+
+		private List<Player> self;
+		private List<Player> rest;
+
+		public List<Player> getSelf() {
+			return self;
+		}
+
+		public void setSelf(List<Player> self) {
+			this.self = self;
+		}
+
+		public List<Player> getRest() {
+			return rest;
+		}
+
+		public void setRest(List<Player> rest) {
+			this.rest = rest;
+		}
+	}
+}

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -10,6 +10,9 @@ cleanerCombat:
   cps:
     limit: 9
     counterInterval: 1000
+    damageDecline:
+      enabled: true # if true, damage declines above the limit, otherwise strict limit
+      factor: 0.1 # -10% damage per cps over the limit
   attackCooldownEnabled: false
   sweepEnabled: false
   sprintResetEnabled: true # should the sprint of the attacker reset upon hitting the victim?
@@ -20,38 +23,39 @@ cleanerCombat:
     strong: false
     knockback: false
     crit: false
-  knockbackLevelMultiplier: 0.6 # a constant to control the knockback sword level
+  knockbackLevelMultiplier: 0.5 # a constant to control the knockback sword level
+  strategy: standard
   normal:
     groundModifier: # modifies knockback in general.
-      type: DIRECT # MULTIPLY or ADD or DIRECT
-      x: 0.625
-      y: 0.5
-      z: 0.625
+      type: MULTIPLY # MULTIPLY or ADD
+      x: 0.1
+      y: 0.05
+      z: 0.1
     airModifier: # modifies knockback if the victim is in the air.
-      type: DIRECT # MULTIPLY or ADD or DIRECT
-      x: 0.625
-      y: 0.5
-      z: 0.625
+      type: MULTIPLY # MULTIPLY or ADD
+      x: 0.1
+      y: 0.1
+      z: 0.1
     waterModifier: # modifies knockback if the victim is in water.
-      type: DIRECT # MULTIPLY or ADD or DIRECT
-      x: 0.625
-      y: 0.5
-      z: 0.625
+      type: MULTIPLY # MULTIPLY or ADD
+      x: 0.1
+      y: 0.05
+      z: 0.1
   sprint: # modifies knockback if the attacker is sprinting.
     groundModifier: # modifies knockback in general.
-      type: DIRECT # MULTIPLY or ADD or DIRECT
+      type: MULTIPLY # MULTIPLY or ADD
       x: 1.0
-      y: 0.6
+      y: 0.05
       z: 1.0
     airModifier: # modifies knockback if the victim is in the air.
-      type: DIRECT
+      type: MULTIPLY
       x: 1.0
-      y: 0.6
+      y: 0.1
       z: 1.0
     waterModifier: # modifies knockback if the victim is in water.
-      type: DIRECT
+      type: MULTIPLY
       x: 1.0
-      y: 0.6
+      y: 0.05
       z: 1.0
   attackerMotion: # modifies motion of attacker upon attacking.
     x: 0.6
@@ -59,7 +63,7 @@ cleanerCombat:
     z: 0.6
   victimMotion: # modifies motion of victim upon getting hit.
     x: 0.5
-    y: 0.5
+    y: 0.1
     z: 0.5
   maxVictimMotion: # maximum motion of victim upon getting hit.
     x: 10.0

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -44,19 +44,19 @@ cleanerCombat:
   sprint: # modifies knockback if the attacker is sprinting.
     groundModifier: # modifies knockback in general.
       type: MULTIPLY # MULTIPLY or ADD
-      x: 1.0
+      x: 0.9
       y: 0.05
-      z: 1.0
+      z: 0.9
     airModifier: # modifies knockback if the victim is in the air.
       type: MULTIPLY
-      x: 1.0
+      x: 0.9
       y: 0.1
-      z: 1.0
+      z: 0.9
     waterModifier: # modifies knockback if the victim is in water.
       type: MULTIPLY
-      x: 1.0
+      x: 0.9
       y: 0.05
-      z: 1.0
+      z: 0.9
   attackerMotion: # modifies motion of attacker upon attacking.
     x: 0.6
     y: 1.0
@@ -278,3 +278,16 @@ invulnerableTicks:
   POISON: 1
   PROJECTILE: 1
   ENTITY_ATTACK: 10
+
+# the warp fruit will roll back to 7 seconds ago
+warpFruit: # logSize * logInterval = how far back in time you go
+  logSize: 35 # log queue size
+  logInterval: 200ms # in milliseconds
+  cooldown: 10s
+  maxDistance: 100 # max warp distance
+  spectralWhileChanneling: true
+  afterEffects:
+    slowness:
+      type: SLOW
+      amplifier: 0
+      duration: 40

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -24,7 +24,7 @@ cleanerCombat:
     knockback: false
     crit: false
   knockbackLevelMultiplier: 0.5 # a constant to control the knockback sword level
-  strategy: standard
+  strategy: classic
   normal:
     groundModifier: # modifies knockback in general.
       type: MULTIPLY # MULTIPLY or ADD


### PR DESCRIPTION
- W-Tapping - Bringing w-tapping back with SprintHandler and changes to AsyncPacketHandler.
- Knockback Strategies - CombatUtil delegates knockback to a KnockbackStrategy; ClassicKnockback - new consistent 1.8 knockback, StandardKnockback - old knockback.
- Gradual Damage Decline - Damage gradually declines as CPS goes over the CPS limit in the DamageListener.
- Warp Fruit - Eat a chorus fruit and teleport back 7 seconds ago; see WarpFruitTracker and WarpFruitListener.

Been testing with following config:
```# alters the base CPS for all players, set enabled to false to disable
alterAttack:
  enabled: true
  speed: 1024
#CombatTag player on login?
ctpOnLogin: true

cleanerCombat:
  maxReach: 6.0
  cps:
    limit: 9
    counterInterval: 1000
    damageDecline:
      enabled: true # if true, damage declines above the limit, otherwise strict limit
      factor: 0.1 # -10% damage per cps over the limit
  attackCooldownEnabled: false
  sweepEnabled: false
  sprintResetEnabled: true # should the sprint of the attacker reset upon hitting the victim?
  waterSprintResetEnabled: false # should the sprint of the attacker reset upon hitting if they are in water?
  knockbackSwordsEnabled: true # should knockback swords work?
  sounds:
    weak: false
    strong: false
    knockback: false
    crit: false
  knockbackLevelMultiplier: 0.5 # a constant to control the knockback sword level
  strategy: classic
  normal:
    groundModifier: # modifies knockback in general.
      type: MULTIPLY # MULTIPLY or ADD
      x: 0.1
      y: 0.05
      z: 0.1
    airModifier: # modifies knockback if the victim is in the air.
      type: MULTIPLY # MULTIPLY or ADD
      x: 0.1
      y: 0.1
      z: 0.1
    waterModifier: # modifies knockback if the victim is in water.
      type: MULTIPLY # MULTIPLY or ADD
      x: 0.1
      y: 0.05
      z: 0.1
  sprint: # modifies knockback if the attacker is sprinting.
    groundModifier: # modifies knockback in general.
      type: MULTIPLY # MULTIPLY or ADD
      x: 0.9
      y: 0.05
      z: 0.9
    airModifier: # modifies knockback if the victim is in the air.
      type: MULTIPLY
      x: 0.9
      y: 0.1
      z: 0.9
    waterModifier: # modifies knockback if the victim is in water.
      type: MULTIPLY
      x: 0.9
      y: 0.05
      z: 0.9
  attackerMotion: # modifies motion of attacker upon attacking.
    x: 0.6
    y: 1.0
    z: 0.6
  victimMotion: # modifies motion of victim upon getting hit.
    x: 0.5
    y: 0.1
    z: 0.5
  maxVictimMotion: # maximum motion of victim upon getting hit.
    x: 10.0
    y: 10.0
    z: 10.0

# gives full control over health / regen, default is full reversion to 1.8 mechanics
foodHealthRegen:
  enabled: true
  interval: 4s
  exhaustionPerHeal: 3.0
  minimumFood: 18
  healthPerCycle: 1.0
  blockFoodRegen: true
  blockSaturationRegen: true
# alters pearl cooldown using vanilla mechanism, optionally combattags on pearl (if combattagplus is available)
pearls:
  #Enable custom cooldown?
  enabled: true
  #Custom pearl cooldown
  cooldown: 16s
  #Combat tag using CTP when pearling?
  combatTag: true

#Config same as above, except with only enabled and cooldown as options
gappleCooldown:
  enabled: true
  cooldown: 16s
#allows adjusting the attack damage of any item by its spigot material identifier
weaponModification:
  netheriteAxe:
    material: NETHERITE_AXE
    damage: 6
  diamondAxe:
    material: DIAMOND_AXE
    damage: 5
  ironAxe:
    material: IRON_AXE
    damage: 4
  stoneAxe:
    material: STONE_AXE
    damage: 3
  goldAxe:
    material: GOLDEN_AXE
    damage: 2
  woodAxe:
    material: WOODEN_AXE
    damage: 1
  netheriteSword:
    material: NETHERITE_SWORD
    damage: 8
  diamondSword:
    material: DIAMOND_SWORD
    damage: 7
  ironSword:
    material: IRON_SWORD
    damage: 6
  stoneSword:
    material: STONE_SWORD
    damage: 5
  goldSword:
    material: GOLDEN_SWORD
    damage: 4
  woodSword:
    material: WOODEN_SWORD
    damage: 3

armourModification:
  diamondHelmet:
    material: DIAMOND_HELMET
    armour: 3
    toughness: 2
    extraDurabilityHits: 1 # how many extra hits a player needs to take for the durability of the piece to fall
  diamondChestplate:
    material: DIAMOND_CHESTPLATE
    armour: 8
    toughness: 2
    extraDurabilityHits: 1
  diamondLeggings:
    material: DIAMOND_LEGGINGS
    armour: 6
    toughness: 2
    extraDurabilityHits: 1
  diamondBoots:
    material: DIAMOND_BOOTS
    armour: 3
    toughness: 2
    extraDurabilityHits: 1
  netheriteHelmet:
    material: NETHERITE_HELMET
    armour: 4
    toughness: 3
    extraDurabilityHits: 1
    knockbackResistance: 0 # knockback resistance is a value between 0 and 1.
  netheriteChestplate:
    material: NETHERITE_CHESTPLATE
    armour: 8
    toughness: 3
    extraDurabilityHits: 1
    knockbackResistance: 0
  netheriteLeggings:
    material: NETHERITE_LEGGINGS
    armour: 6
    toughness: 3
    extraDurabilityHits: 1
    knockbackResistance: 0
  netheriteBoots:
    material: NETHERITE_BOOTS
    armour: 4
    toughness: 3
    extraDurabilityHits: 1
    knockbackResistance: 0

#allows disabling enchantments. Use official spigot identifiers from https://hub.spigotmc.org/javadocs/spigot/org/bukkit/enchantments/Enchantment.html
#This will not remove them from enchanting, but simply remove the enchant as soon as the item is touched
disabledEnchantments:
  - MENDING
  - FROST_WALKER

potions:
  #Allows applying a multiplier to the intensity of potions. Intensities <= 1.0 will always work fine, but intensities > 1
  #may lead to unintended results for instant effects like INSTANT_HEALTH.
  #All entries may have the following entries:
  # type:
  #   A potion type (https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionType.html)
  # upgraded:
  #   Boolean to specify whether the pot is upgraded (tier 2)
  # extended:
  #   Boolean to specify whether the pot is extended
  # splash:
  #   Boolean to specify whether the pot is splash
  # multiplier:
  #   Double value, the multiplier applied to the duration. May not be negative and defaults to 1.0

  #   ---
  #All values specifying the kind of option are optional and will wildcard if not specified, for example:

  #An entry applying to all extended splash potions:
  #    splash:
  #      splash: true
  #      extended: true
  #      multiplier: 0.8

  #Or one applying only to speed 8, both splash&drinkable
  #    speed8:
  #      type: SPEED
  #      extended: true
  #      multiplier: 0.8
  potIntensity:
    splash:
      #All splash pots reduced
      splash: true
      multiplier: 1.0
    #Except for health
    health:
      type: INSTANT_HEAL
      multiplier: 1.0
  #Multiplier applied to the health gain from all health potions
  healthMultiplier: 1.5
  minIntensityCutOff: 0.3 # minimum intensity for non-thrower to steal some health effect.
  minIntensityImpact: 0.5 # minimum intensity for thrower to get full health effect.

velocity:
  #In newer Minecraft versions when a player launches a projectile the players velocity will be added to the projectiles base velocity. This can lead to
  #weird behavior sometimes and reverted with this setting. Add entity types (https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/EntityType.html)
  #of projectiles to the list to revert their behavior regarding initial velocity to 1.7
  ENDER_PEARL:
    type: REVERTED
    power: 1.4
  SPLASH_POTION:
    type: REVERTED
    power: 0.5
    vertical: 0.4
    horizontal: 0.4
    pitchOffset: -20

#This option allows modifying the damage dealt by/to players based on certain properties. All entries look like this:

#  SWORD:
#    multiplier: 1.2
#    mode: LINEAR
#    flatAddition: 0.0

#Key of the entry is the type of damage modified, allowed here are: ALL, SWORD, SHARPNESS_ENCHANT, STRENGTH_EFFECT, ARROW, POWER_ENCHANT, CRIT
#'multiplier' is the multiplier applied to the preexisting vanilla damage, defaults to 1.0
#'mode' is the mode used to apply the multiplier for types with different levels like SHARPNESS_ENCHANT. Allowed are LINEAR and EXPONENTIAL
#'flatAddition' is a flat amount added per level. Flat addition is applied before the multiplier

#The order in which modifiers are applied is: ALL, ARROW, POWER_ENCHANT, STRENGTH_EFFECT, SWORD, SHARPNESS_ENCHANT, CRIT
#Note that these effects are applied after vanilla damage additions and before vanilla damage reductions
damageModifiers:
  #Decrease all damage by 20 %
  ALL:
    multiplier: 0.8
    mode: DIRECT
  #Increase sword damage by 25 %
  SHARPNESS_ENCHANT:
    multiplier: 1.0
    mode: DIRECT
  SWORD:
    mode: DIRECT
    multiplier: 1.0
  CRIT:
    mode: DIRECT
    multiplier: 0.86
  STRENGTH_EFFECT:
    mode: DIRECT
    multiplier: 0.8

invulTicksEnabled: false
invulnerableTicks:
  POISON: 1
  PROJECTILE: 1
  ENTITY_ATTACK: 10

# the warp fruit will roll back to 7 seconds ago
warpFruit: # logSize * logInterval = how far back in time you go
  logSize: 35 # log queue size
  logInterval: 200ms # in milliseconds
  cooldown: 10s
  maxDistance: 100 # max warp distance
  spectralWhileChanneling: true
  afterEffects:
    slowness:
      type: SLOW
      amplifier: 0
      duration: 40
```